### PR TITLE
Update GitOops and revert back to S3 backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,6 @@ Optional additional context or background information.
 
 ## Terraform Standards
 
-Keep configuration out of of Terraform (i.e. user data)
-
 ### Required Files
 
 1. **settings.tf** - Provider configuration and version constraints

--- a/base/aws/settings.tf
+++ b/base/aws/settings.tf
@@ -9,11 +9,11 @@ terraform {
       version = "~> 5.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
       version = "~> 2.5.0"
     }
     tls = {
-      source = "hashicorp/tls"
+      source  = "hashicorp/tls"
       version = "~> 4.1.0"
     }
   }

--- a/scenarios/gitoops/ansible/playbook.yaml
+++ b/scenarios/gitoops/ansible/playbook.yaml
@@ -3,7 +3,7 @@
   hosts: main
   become: true
   vars:
-    atlantis_zip_url: "https://github.com/runatlantis/atlantis/releases/download/v0.28.1/atlantis_linux_amd64.zip"
+    atlantis_zip_url: "https://github.com/runatlantis/atlantis/releases/download/v0.34.0/atlantis_linux_amd64.zip"
     atlantis_binary_dest_dir: "/usr/local/bin"
     atlantis_service_name: "atlantis"
     atlantis_webhook_secret: "82df5474-2933-11ef-9454-0242ac120002"
@@ -36,6 +36,12 @@
   roles:
     - {role: l3d.git.gitea, tags: forgejo}
   tasks:
+    - name: Set a hostname
+      ansible.builtin.hostname:
+        name: "{{ gitea_domain }}"
+      tags:
+        - hostname
+
     - name: Update APT packages
       ansible.builtin.apt:
         update_cache: true
@@ -49,7 +55,6 @@
           - tcpdump
           - telnet
           - ufw
-          - jq
 
     - name: Update all packages to their latest version
       ansible.builtin.apt:
@@ -74,7 +79,9 @@
 
     - name: Install Nginx
       ansible.builtin.apt:
-        name: nginx
+        pkg:
+          - nginx
+          - jq
         state: present
         update_cache: true
       tags:
@@ -177,6 +184,14 @@
     - name: Import flags
       ansible.builtin.include_vars:
         file: flags.yaml
+
+    - name: Allow passwordless sudo
+      ansible.builtin.lineinfile:
+        dest: /etc/sudoers
+        state: present
+        regexp: "^%sudo"
+        line: "%sudo ALL=(ALL:ALL) NOPASSWD: ALL"
+        validate: "visudo -cf %s"
 
     - name: Create Linux non-root user
       ansible.builtin.include_tasks:
@@ -352,11 +367,3 @@
         owner: root
         group: root
         content: "{{ 'vmGoat{' + root_flag + '}' }}"
-
-    - name: Create root readme
-      ansible.builtin.copy:
-        src: "templates/readme"
-        dest: "/root/readme"
-        owner: root
-        group: root
-        mode: '0600'

--- a/scenarios/gitoops/ansible/repos/public/local.tfstate
+++ b/scenarios/gitoops/ansible/repos/public/local.tfstate
@@ -1,0 +1,535 @@
+{
+  "version": 4,
+  "terraform_version": "1.11.4",
+  "serial": 11,
+  "lineage": "dc628c96-0fef-aa6c-a80a-04bbc06abd40",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_ami",
+      "name": "ubuntu",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "architecture": "x86_64",
+            "arn": "arn:aws:ec2:us-east-1::image/ami-0655cec52acf2717b",
+            "block_device_mappings": [
+              {
+                "device_name": "/dev/sda1",
+                "ebs": {
+                  "delete_on_termination": "true",
+                  "encrypted": "false",
+                  "iops": "0",
+                  "snapshot_id": "snap-0ea0715c3204157c8",
+                  "throughput": "0",
+                  "volume_size": "8",
+                  "volume_type": "gp2"
+                },
+                "no_device": "",
+                "virtual_name": ""
+              },
+              {
+                "device_name": "/dev/sdb",
+                "ebs": {},
+                "no_device": "",
+                "virtual_name": "ephemeral0"
+              },
+              {
+                "device_name": "/dev/sdc",
+                "ebs": {},
+                "no_device": "",
+                "virtual_name": "ephemeral1"
+              }
+            ],
+            "boot_mode": "uefi-preferred",
+            "creation_date": "2025-03-27T06:52:03.000Z",
+            "deprecation_time": "2027-03-27T06:52:03.000Z",
+            "description": "Canonical, Ubuntu, 22.04, amd64 jammy image",
+            "ena_support": true,
+            "executable_users": null,
+            "filter": [
+              {
+                "name": "architecture",
+                "values": [
+                  "x86_64"
+                ]
+              },
+              {
+                "name": "name",
+                "values": [
+                  "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+                ]
+              },
+              {
+                "name": "root-device-type",
+                "values": [
+                  "ebs"
+                ]
+              },
+              {
+                "name": "virtualization-type",
+                "values": [
+                  "hvm"
+                ]
+              }
+            ],
+            "hypervisor": "xen",
+            "id": "ami-0655cec52acf2717b",
+            "image_id": "ami-0655cec52acf2717b",
+            "image_location": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250327",
+            "image_owner_alias": "amazon",
+            "image_type": "machine",
+            "imds_support": "",
+            "include_deprecated": false,
+            "kernel_id": "",
+            "last_launched_time": "",
+            "most_recent": true,
+            "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20250327",
+            "name_regex": null,
+            "owner_id": "099720109477",
+            "owners": [
+              "amazon"
+            ],
+            "platform": "",
+            "platform_details": "Linux/UNIX",
+            "product_codes": [],
+            "public": true,
+            "ramdisk_id": "",
+            "root_device_name": "/dev/sda1",
+            "root_device_type": "ebs",
+            "root_snapshot_id": "snap-0ea0715c3204157c8",
+            "sriov_net_support": "simple",
+            "state": "available",
+            "state_reason": {
+              "code": "UNSET",
+              "message": "UNSET"
+            },
+            "tags": {},
+            "timeouts": null,
+            "tpm_support": "",
+            "uefi_data": null,
+            "usage_operation": "RunInstances",
+            "virtualization_type": "hvm"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "aws_route53_zone",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:route53:::hostedzone/Z082347525N0U4KNV001M",
+            "caller_reference": "b9bcd3bd-6358-4a02-af5f-37793b65cd73",
+            "comment": "",
+            "id": "Z082347525N0U4KNV001M",
+            "linked_service_description": null,
+            "linked_service_principal": null,
+            "name": "gitoops.local",
+            "name_servers": [
+              "ns-1616.awsdns-10.co.uk",
+              "ns-388.awsdns-48.com",
+              "ns-1099.awsdns-09.org",
+              "ns-684.awsdns-21.net"
+            ],
+            "primary_name_server": "ns-1616.awsdns-10.co.uk",
+            "private_zone": false,
+            "resource_record_set_count": 3,
+            "tags": {},
+            "vpc_id": null,
+            "zone_id": "Z082347525N0U4KNV001M"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "aws_subnet",
+      "name": "subnet",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:0123456789:subnet/subnet-098198512d814b738",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-1a",
+            "availability_zone_id": "use1-az6",
+            "available_ip_address_count": 250,
+            "cidr_block": "10.1.0.0/24",
+            "customer_owned_ipv4_pool": "",
+            "default_for_az": false,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "filter": [
+              {
+                "name": "tag:Name",
+                "values": [
+                  "vmGoat"
+                ]
+              }
+            ],
+            "id": "subnet-098198512d814b738",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "0123456789",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "state": "available",
+            "tags": {
+              "Name": "vmGoat"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04836164a33a3b273"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "aws_vpc",
+      "name": "vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:0123456789:vpc/vpc-04836164a33a3b273",
+            "cidr_block": "10.1.0.0/16",
+            "cidr_block_associations": [
+              {
+                "association_id": "vpc-cidr-assoc-04b2eebf76928e05b",
+                "cidr_block": "10.1.0.0/16",
+                "state": "associated"
+              }
+            ],
+            "default": false,
+            "dhcp_options_id": "dopt-8f3c7ff5",
+            "enable_dns_hostnames": false,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "filter": [
+              {
+                "name": "tag:Name",
+                "values": [
+                  "vmGoat"
+                ]
+              }
+            ],
+            "id": "vpc-04836164a33a3b273",
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": "rtb-0c15b3900656a4ad0",
+            "owner_id": "0123456789",
+            "state": null,
+            "tags": {
+              "Name": "vmGoat"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "gitoops",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-0655cec52acf2717b",
+            "arn": "arn:aws:ec2:us-east-1:0123456789:instance/i-0fdb819ee7502c154",
+            "associate_public_ip_address": true,
+            "availability_zone": "us-east-1a",
+            "capacity_reservation_specification": [
+              {
+                "capacity_reservation_preference": "open",
+                "capacity_reservation_target": []
+              }
+            ],
+            "cpu_core_count": 1,
+            "cpu_options": [
+              {
+                "amd_sev_snp": "",
+                "core_count": 1,
+                "threads_per_core": 2
+              }
+            ],
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_stop": false,
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "enable_primary_ipv6": null,
+            "enclave_options": [
+              {
+                "enabled": false
+              }
+            ],
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": "",
+            "host_resource_group_arn": null,
+            "iam_instance_profile": "",
+            "id": "i-0fdb819ee7502c154",
+            "instance_initiated_shutdown_behavior": "stop",
+            "instance_lifecycle": "",
+            "instance_market_options": [],
+            "instance_state": "running",
+            "instance_type": "t3.medium",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "gitoops",
+            "launch_template": [],
+            "maintenance_options": [
+              {
+                "auto_recovery": "default"
+              }
+            ],
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_protocol_ipv6": "disabled",
+                "http_put_response_hop_limit": 1,
+                "http_tokens": "optional",
+                "instance_metadata_tags": "disabled"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "placement_partition_number": 0,
+            "primary_network_interface_id": "eni-0115821d0db6e99c9",
+            "private_dns": "ip-10-1-0-123.ec2.internal",
+            "private_dns_name_options": [
+              {
+                "enable_resource_name_dns_a_record": false,
+                "enable_resource_name_dns_aaaa_record": false,
+                "hostname_type": "ip-name"
+              }
+            ],
+            "private_ip": "10.1.0.123",
+            "public_dns": "",
+            "public_ip": "1.1.1.1",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/sda1",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "tags": {
+                  "project": "gitoops",
+                  "terraform": "true"
+                },
+                "tags_all": {
+                  "project": "gitoops",
+                  "terraform": "true"
+                },
+                "throughput": 0,
+                "volume_id": "vol-036e38f8471d1ea07",
+                "volume_size": 8,
+                "volume_type": "gp2"
+              }
+            ],
+            "secondary_private_ips": [],
+            "security_groups": [],
+            "source_dest_check": true,
+            "spot_instance_request_id": "",
+            "subnet_id": "subnet-098198512d814b738",
+            "tags": {
+              "Name": "gitoops"
+            },
+            "tags_all": {
+              "Name": "gitoops",
+              "project": "gitoops",
+              "terraform": "true"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null,
+            "vpc_security_group_ids": [
+              "sg-0b9913296bc457ed0"
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_security_group.gitoops",
+            "data.aws_ami.ubuntu",
+            "data.aws_subnet.subnet",
+            "data.aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route53_record",
+      "name": "gitoops",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "alias": [],
+            "allow_overwrite": null,
+            "cidr_routing_policy": [],
+            "failover_routing_policy": [],
+            "fqdn": "gitoops.local",
+            "geolocation_routing_policy": [],
+            "geoproximity_routing_policy": [],
+            "health_check_id": "",
+            "id": "Z082347525N0U4KNV001M_gitoops.local_A",
+            "latency_routing_policy": [],
+            "multivalue_answer_routing_policy": false,
+            "name": "gitoops.local",
+            "records": [
+              "1.1.1.1"
+            ],
+            "set_identifier": "",
+            "timeouts": null,
+            "ttl": 300,
+            "type": "A",
+            "weighted_routing_policy": [],
+            "zone_id": "Z082347525N0U4KNV001M"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjE4MDAwMDAwMDAwMDAsInVwZGF0ZSI6MTgwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMiJ9",
+          "dependencies": [
+            "aws_instance.gitoops",
+            "aws_security_group.gitoops",
+            "data.aws_ami.ubuntu",
+            "data.aws_route53_zone.public",
+            "data.aws_subnet.subnet",
+            "data.aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "gitoops",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-1:0123456789:security-group/sg-0b9913296bc457ed0",
+            "description": "Allow traffic to vmGoat gitoops server",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [
+                  "::/0"
+                ],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-0b9913296bc457ed0",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "HTTP",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "HTTPS",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 443
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "SSH into server",
+                "from_port": 22,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 22
+              }
+            ],
+            "name": "gitoops",
+            "name_prefix": "",
+            "owner_id": "0123456789",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "gitoops"
+            },
+            "tags_all": {
+              "Name": "gitoops",
+              "project": "gitoops",
+              "terraform": "true"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04836164a33a3b273"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "data.aws_vpc.vpc"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/scenarios/gitoops/ansible/repos/public/settings.tf.txt
+++ b/scenarios/gitoops/ansible/repos/public/settings.tf.txt
@@ -2,8 +2,8 @@ terraform {
   required_version = "1.11.4"
 
   backend "s3" {
-    bucket = "cloudformation-examples"
-    key    = "vmGoat/gitoops/terraform.tfstate"
+    bucket = "{{ BUCKET_NAME }}"
+    key    = "gitcorp/terraform.tfstate"
     region = "us-east-1"
   }
 

--- a/scenarios/gitoops/ansible/tasks/gitea_oneoffs.yaml
+++ b/scenarios/gitoops/ansible/tasks/gitea_oneoffs.yaml
@@ -272,7 +272,7 @@
         email: "{{ gitea_user_username }}@{{ gitea_domain }}",
         name: "{{ gitea_user_username }}"
       }
-      content: "{{ lookup('ansible.builtin.file', 'repos/{{ gitea_repo }}/tmp-tfstate') | b64encode }}"
+      content: "{{ lookup('ansible.builtin.file', 'repos/{{ gitea_repo }}/local.tfstate') | b64encode }}"
     body_format: json
     return_content: true
     status_code: 201
@@ -409,6 +409,23 @@
         - gitea_oneoffs
         - gitea_files
 
+    - name: Read the /vars.env file
+      ansible.builtin.slurp:
+        src: /vars.env
+      register: vars_env_file_content
+      tags:
+        - gitea
+        - gitea_oneoffs
+        - gitea_files
+
+    - name: Parse environment variables from the vars.env file
+      ansible.builtin.set_fact:
+        env_vars: "{{ vars_env_file_content['content'] | b64decode | regex_findall('([^=]+)=(.*)') | items2dict(key_name=0, value_name=1) }}"
+      tags:
+        - gitea
+        - gitea_oneoffs
+        - gitea_files
+
     - name: Commit updated settings.tf file
       ansible.builtin.uri:
         url: "http://localhost:3000/api/v1/repos/{{ gitea_org_name }}/{{ gitea_repo }}/contents/settings.tf"
@@ -427,7 +444,7 @@
             email: "{{ gitea_user_username }}@{{ gitea_domain }}",
             name: "{{ gitea_user_username }}"
           }
-          content: "{{ lookup('ansible.builtin.file', 'repos/{{ gitea_repo }}/settings.tf.txt') | b64encode }}"
+          content: "{{ lookup('ansible.builtin.template', 'repos/{{ gitea_repo }}/settings.tf.txt', template_vars=env_vars) | b64encode }}"
           message: "Update backend to use S3"
           sha: "{{ (settings_file_sha.json.sha) }}"
         body_format: json

--- a/scenarios/gitoops/ansible/templates/readme
+++ b/scenarios/gitoops/ansible/templates/readme
@@ -1,7 +1,0 @@
-Thanks for playing!
-
-I hope you had fun and learned something new about Git/GitOps
-
-
-If your interested in learning about how I created this scenario I have a writeup on my blog.
-https://infrasec.sh/post/vmGoat-creating-gitoops/

--- a/scenarios/gitoops/terraform/data.tf
+++ b/scenarios/gitoops/terraform/data.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 data "aws_vpc" "this" {
   state = "available"
   tags = {

--- a/scenarios/gitoops/terraform/ec2.tf
+++ b/scenarios/gitoops/terraform/ec2.tf
@@ -14,6 +14,11 @@ resource "aws_instance" "this" {
     data.aws_security_group.this.id
   ]
 
+  user_data = <<-EOF
+    #!/bin/bash
+    echo 'BUCKET_NAME=${aws_s3_bucket.this.bucket}' > /vars.env
+  EOF
+
   tags = {
     Name = "GitOops"
   }

--- a/scenarios/gitoops/terraform/s3.tf
+++ b/scenarios/gitoops/terraform/s3.tf
@@ -1,0 +1,57 @@
+resource "random_string" "random" {
+  length  = 16
+  special = false
+  upper   = false
+}
+
+
+resource "aws_s3_bucket" "this" {
+  bucket = "gitoops-${random_string.random.result}"
+}
+
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = true
+  restrict_public_buckets = false
+}
+
+
+resource "aws_s3_bucket_policy" "this" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.this
+  ]
+
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+
+resource "aws_s3_object" "state" {
+  key    = "/gitcorp/terraform.tfstate"
+  bucket = aws_s3_bucket.this.id
+  content = templatefile("src/tfstate.tmpl", {
+    ACCOUNT_ID = data.aws_caller_identity.current.account_id
+    AWS_REGION = data.aws_region.current.name
+  })
+}

--- a/scenarios/gitoops/terraform/settings.tf
+++ b/scenarios/gitoops/terraform/settings.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.0"
+    }
   }
 }
 

--- a/scenarios/gitoops/terraform/src/tfstate.tmpl
+++ b/scenarios/gitoops/terraform/src/tfstate.tmpl
@@ -15,7 +15,7 @@
           "schema_version": 0,
           "attributes": {
             "architecture": "x86_64",
-            "arn": "arn:aws:ec2:us-east-1::image/ami-0655cec52acf2717b",
+            "arn": "arn:aws:ec2:${AWS_REGION}::image/ami-0655cec52acf2717b",
             "block_device_mappings": [
               {
                 "device_name": "/dev/sda1",
@@ -160,9 +160,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:0123456789:subnet/subnet-098198512d814b738",
+            "arn": "arn:aws:ec2:${AWS_REGION}:${ACCOUNT_ID}:subnet/subnet-098198512d814b738",
             "assign_ipv6_address_on_creation": false,
-            "availability_zone": "us-east-1a",
+            "availability_zone": "${AWS_REGION}a",
             "availability_zone_id": "use1-az6",
             "available_ip_address_count": 250,
             "cidr_block": "10.1.0.0/24",
@@ -187,7 +187,7 @@
             "map_customer_owned_ip_on_launch": false,
             "map_public_ip_on_launch": false,
             "outpost_arn": "",
-            "owner_id": "0123456789",
+            "owner_id": "${ACCOUNT_ID}",
             "private_dns_hostname_type_on_launch": "ip-name",
             "state": "available",
             "tags": {
@@ -209,7 +209,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:0123456789:vpc/vpc-04836164a33a3b273",
+            "arn": "arn:aws:ec2:${AWS_REGION}:${ACCOUNT_ID}:vpc/vpc-04836164a33a3b273",
             "cidr_block": "10.1.0.0/16",
             "cidr_block_associations": [
               {
@@ -236,7 +236,7 @@
             "ipv6_association_id": "",
             "ipv6_cidr_block": "",
             "main_route_table_id": "rtb-0c15b3900656a4ad0",
-            "owner_id": "0123456789",
+            "owner_id": "${ACCOUNT_ID}",
             "state": null,
             "tags": {
               "Name": "vmGoat"
@@ -257,9 +257,9 @@
           "schema_version": 1,
           "attributes": {
             "ami": "ami-0655cec52acf2717b",
-            "arn": "arn:aws:ec2:us-east-1:0123456789:instance/i-0fdb819ee7502c154",
+            "arn": "arn:aws:ec2:${AWS_REGION}:${ACCOUNT_ID}:instance/i-0fdb819ee7502c154",
             "associate_public_ip_address": true,
-            "availability_zone": "us-east-1a",
+            "availability_zone": "${AWS_REGION}a",
             "capacity_reservation_specification": [
               {
                 "capacity_reservation_preference": "open",
@@ -337,7 +337,7 @@
             ],
             "private_ip": "10.1.0.123",
             "public_dns": "",
-            "public_ip": "54.80.176.18",
+            "public_ip": "1.1.1.1",
             "root_block_device": [
               {
                 "delete_on_termination": true,
@@ -404,7 +404,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:0123456789:key-pair/gitoops",
+            "arn": "arn:aws:ec2:${AWS_REGION}:${ACCOUNT_ID}:key-pair/gitoops",
             "fingerprint": "e9:17:f4:4d:be:7d:36:5a:c1:c0:31:ab:b4:ff:6a:7e",
             "id": "gitoops",
             "key_name": "gitoops",
@@ -448,7 +448,7 @@
             "multivalue_answer_routing_policy": false,
             "name": "gitoops.local",
             "records": [
-              "54.80.176.18"
+              "1.1.1.1"
             ],
             "set_identifier": "",
             "timeouts": null,
@@ -481,7 +481,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-1:0123456789:security-group/sg-0b9913296bc457ed0",
+            "arn": "arn:aws:ec2:${AWS_REGION}:${ACCOUNT_ID}:security-group/sg-0b9913296bc457ed0",
             "description": "Allow traffic to vmGoat gitoops server",
             "egress": [
               {
@@ -544,7 +544,7 @@
             ],
             "name": "gitoops",
             "name_prefix": "",
-            "owner_id": "0123456789",
+            "owner_id": "${ACCOUNT_ID}",
             "revoke_rules_on_delete": false,
             "tags": {
               "Name": "gitoops"


### PR DESCRIPTION
#### Overview of Changes
GitOops
- Switch TF state to be stored in S3 (Scenario was initially deployed this way)
- Update Atlantis to latest release
- Have state have correct region & account id

#### Testing
Yes, ran through scenario and confirmed new update are working
